### PR TITLE
fix: do not use attempt in onError test

### DIFF
--- a/exercises/src/test/scala/exercises/action/fp/IOTest.scala
+++ b/exercises/src/test/scala/exercises/action/fp/IOTest.scala
@@ -74,7 +74,7 @@ class IOTest extends AnyFunSuite with ScalaCheckDrivenPropertyChecks {
     val action = IO { counter += 1; "" }.onError(_ => IO(counter *= 2))
     assert(counter == 0) // nothing happened before unsafeRun
 
-    val result = action.attempt.unsafeRun()
+    val result = Try(action.unsafeRun())
     assert(counter == 1) // first action was executed but not the callback
     assert(result == Success(""))
   }


### PR DESCRIPTION
Hi @julien-truffaut 

Just bought your course on `udemy` and thanks, it's awesome.

The `onError` test in `IOTest` is using `attempt` at a point where it is not implemented and thus I had to implement or change the test in order to make the `onError` test green.

Here's a fix to realign the code with what you have on video.

👋